### PR TITLE
Update to match node version for better type-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: Looking for the node version? Check [memoizy](https://github.com/ramiel/me
 Memoize the return value of a function
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
 const fact = (n) => {
   if(n === 1) return n;
@@ -58,7 +58,7 @@ and `options` is an (optional) object with the following keys:
 ### Expire data
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
 const double = memoizy(a => a * 2, {maxAge: 2000});
 
@@ -71,7 +71,7 @@ double(2); // Original function is called again and 4 is returned. The value is 
 ### Discard rejected promises
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
 const originalFn = async (a) => {
   if(a > 10) return 100;
@@ -87,7 +87,7 @@ await memoized(15); // returns 100 and the value is memoized
 ### Discard some values
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
 const originalFn = (a) => {
   if(a > 10) return true;
@@ -103,7 +103,7 @@ await memoized(15); // returns true and it's memoized
 ### Delete and Clear
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
 const sum = (a, b) => a + b;
 
@@ -129,7 +129,7 @@ If the cache doesn't support clear, it's up to you not to call it. In case an er
 Look [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#Implementing_a_WeakMap-like_class_with_a_.clear()_method) for a way to use a weak map with clear implementd, as cache.
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/mod.ts';
+import { memoizy } from 'https://deno.land/x/memoizy/mod.ts';
 
  const AlternativeCacheFactory = () => {
   let data = {};
@@ -173,7 +173,7 @@ It has the same features and the following differences:
 An example
 
 ```js
-import memoizy from 'https://deno.land/x/memoizy/fp.ts';
+import { fp as memoizy } from 'https://deno.land/x/memoizy/fp.ts';
 
 // since it is curried, we can pass just options and a new function will be returned
 const memoizeFor5Seconds = memoizy({maxage: 5 * 1000});

--- a/fp.ts
+++ b/fp.ts
@@ -1,14 +1,26 @@
-import memoizy, { MemoizyOptions, MemoizedFunction } from "./mod.ts";
+import { memoizy, MemoizyOptions, MemoizedFunction } from './mod.ts';
 
-const curry: any = (fn: Function, ...args: any[]) =>
-  args.length >= fn.length ? fn(...args) : curry.bind(null, fn, ...args);
+const curry: any = (fn: Function, ...args: unknown[]) =>
+  args.length >= fn.length
+    ? fn(...args)
+    : curry.bind(null, fn, ...args);
 
-const curried = curry(<TResult>(options: MemoizyOptions<TResult>, fn: (...args: any[]) => TResult) => memoizy(fn, options))
+const curried = curry(
+  <TResult, TArgs extends any[]>(
+    options: MemoizyOptions<TArgs, TResult>,
+    fn: (...args: unknown[]) => TResult,
+  ) => memoizy(fn, options),
+);
 
-function fpmemoizy<TResult>( options: MemoizyOptions<TResult>, fn: (...args: any[]) => TResult ) : MemoizedFunction<TResult>;
-function fpmemoizy(options: MemoizyOptions): (<TResult>(fn: (...args: any[]) => TResult) => MemoizedFunction<TResult>);
-function fpmemoizy(...args: any[]) {
+export function fp<TResult, TArgs extends any[]>(
+  options: MemoizyOptions<TArgs, TResult>,
+  fn: (...args: TArgs) => TResult,
+): MemoizedFunction<TResult, TArgs>;
+export function fp<TArgs extends any[]>(
+  options: MemoizyOptions<TArgs>,
+): <TResult>(
+  fn: (...args: TArgs) => TResult,
+) => MemoizedFunction<TResult, TArgs>;
+export function fp<TArgs extends any[]>(...args: TArgs) {
   return curried(...args);
 }
-
-export default fpmemoizy;


### PR DESCRIPTION
This PR updates the implementation to match the current implementation of the Node version of the project, which has better handling of types: the wrapped function's argument types are now preserved. This PR copies over the files exactly from the Node version besides the import line and a dropped eslint comment from the top.

This does change the main functions in mod.ts and fp.ts to become regular named exports instead of default exports. It is a breaking change but I think the consistency is good.

This PR also copies over the redis example in the readme and ports it over for Deno.